### PR TITLE
Initialize Godot project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Godot-specific
+.import/
+.export/
+.godot/
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# td
+# Wintermaul Wars Classic
+
+This repository contains the initial project structure for **Wintermaul Wars Classic**, a tower defense game inspired by the classic Warcraft III custom map.
+
+The project uses the [Godot Engine](https://godotengine.org/) and is written in GDScript.
+
+## Getting Started
+
+1. Install [Godot 4](https://godotengine.org/download).
+2. Open the project directory in Godot.
+3. Run the project to see a basic scene printing a welcome message.
+
+## Project Structure
+
+- `project.godot` – Godot project configuration.
+- `scenes/` – Godot scene files.
+- `scripts/` – GDScript source files.
+
+## License
+
+This project is licensed under the MIT License.

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,6 @@
+[gd_project]
+config_version=5
+
+[application]
+config/name="Wintermaul Wars Classic"
+run/main_scene="res://scenes/main.tscn"

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://scripts/main.gd" type="Script" id=1]
+
+[node name="Main" type="Node2D"]
+script = ExtResource(1)

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -1,0 +1,4 @@
+extends Node2D
+
+func _ready() -> void:
+    print("Welcome to Wintermaul Wars Classic!")


### PR DESCRIPTION
## Summary
- add initial Godot configuration and entry scene
- scaffold main script printing a welcome message
- document project setup and add MIT license

## Testing
- `godot3 --version`
- `godot3 --no-window --path . --quit` *(fails: X11 Display is not available)*

------
https://chatgpt.com/codex/tasks/task_b_68a1def4a8948321995789bd23847a54