### PR TITLE
Prevent null curve access for path in _ready

### DIFF
--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -6,6 +6,8 @@ extends Node2D
 @onready var tower_scene := preload("res://scenes/tower.tscn")
 
 func _ready() -> void:
+    if path.curve == null:
+        path.curve = Curve2D.new()
     path.curve.clear_points()
     path.curve.add_point(Vector2(0, 300))
     path.curve.add_point(Vector2(600, 300))


### PR DESCRIPTION
## Summary
- Initialize a Curve2D for the path if none exists before clearing and adding points

## Testing
- `godot3 --headless --path . --quit` *(fails: project config_version 5 incompatible with engine version)*
- `/tmp/godot4/Godot_v4.2.1-stable_linux.x86_64 --headless --path . --quit`

------
https://chatgpt.com/codex/tasks/task_b_68a1e31a37a08321978b6ad19fcf0bc2