### PR TITLE
Add basic visuals for creeps and towers

### DIFF
--- a/scripts/creep.gd
+++ b/scripts/creep.gd
@@ -5,23 +5,35 @@ extends Node2D
 var path: Path2D
 var distance: float = 0.0
 
+
 func _enter_tree() -> void:
-    add_to_group("creeps")
+	add_to_group("creeps")
+
 
 func _exit_tree() -> void:
-    remove_from_group("creeps")
+	remove_from_group("creeps")
+
+
+func _ready() -> void:
+	queue_redraw()
+
 
 func take_damage(amount: int) -> void:
-    health -= amount
-    if health <= 0:
-        queue_free()
+	health -= amount
+	if health <= 0:
+		queue_free()
+
 
 func _process(delta: float) -> void:
-    if path == null:
-        return
-    distance += speed * delta
-    var curve := path.curve
-    var length := curve.get_baked_length()
-    global_position = path.to_global(curve.sample_baked(distance))
-    if distance >= length:
-        queue_free()
+	if path == null:
+		return
+	distance += speed * delta
+	var curve := path.curve
+	var length := curve.get_baked_length()
+	global_position = path.to_global(curve.sample_baked(distance))
+	if distance >= length:
+		queue_free()
+
+
+func _draw() -> void:
+	draw_circle(Vector2.ZERO, 8.0, Color.RED)

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -2,8 +2,9 @@ extends Node2D
 
 @onready var path: Path2D = $Path2D
 @onready var spawn_timer: Timer = $SpawnTimer
-@onready var creep_scene := preload("res://scenes/creep.tscn")
-@onready var tower_scene := preload("res://scenes/tower.tscn")
+@onready var creep_scene: PackedScene = preload("res://scenes/creep.tscn")
+@onready var tower_scene: PackedScene = preload("res://scenes/tower.tscn")
+
 
 func _ready() -> void:
 	if path.curve == null:
@@ -14,13 +15,15 @@ func _ready() -> void:
 	spawn_timer.timeout.connect(_on_spawn_timer_timeout)
 	spawn_timer.start()
 
+
 func _on_spawn_timer_timeout() -> void:
-	var creep = creep_scene.instantiate()
+	var creep := creep_scene.instantiate()
 	creep.path = path
 	add_child(creep)
 
+
 func _unhandled_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-		var tower = tower_scene.instantiate()
+		var tower := tower_scene.instantiate()
 		tower.global_position = event.position
 		add_child(tower)

--- a/scripts/tower.gd
+++ b/scripts/tower.gd
@@ -5,20 +5,30 @@ extends Node2D
 @export var damage: int = 5
 var cooldown: float = 0.0
 
+
+func _ready() -> void:
+	queue_redraw()
+
+
 func _process(delta: float) -> void:
-    cooldown -= delta
-    if cooldown <= 0.0:
-        var target = _get_target()
-        if target:
-            target.take_damage(damage)
-            cooldown = 1.0 / fire_rate
+	cooldown -= delta
+	if cooldown <= 0.0:
+		var target = _get_target()
+		if target:
+			target.take_damage(damage)
+			cooldown = 1.0 / fire_rate
+
 
 func _get_target() -> Node2D:
-    var closest: Node2D = null
-    var closest_dist := attack_range
-    for creep in get_tree().get_nodes_in_group("creeps"):
-        var dist := global_position.distance_to(creep.global_position)
-        if dist < closest_dist:
-            closest = creep
-            closest_dist = dist
-    return closest
+	var closest: Node2D = null
+	var closest_dist := attack_range
+	for creep in get_tree().get_nodes_in_group("creeps"):
+		var dist := global_position.distance_to(creep.global_position)
+		if dist < closest_dist:
+			closest = creep
+			closest_dist = dist
+	return closest
+
+
+func _draw() -> void:
+	draw_circle(Vector2.ZERO, 12.0, Color.BLUE)


### PR DESCRIPTION
## Summary
- Make creeps and towers visible by drawing colored circles
- Type and reformat main script for clarity

## Testing
- `gdlint scripts/main.gd scripts/creep.gd scripts/tower.gd`
- ⚠️ `godot --headless scenes/main.tscn` (command not found; engine unavailable)


------
https://chatgpt.com/codex/tasks/task_b_68a1e81c3938832189df86b324ffad62