### PR TITLE
Add health bar and max health property to creeps

### DIFF
--- a/scenes/creep.tscn
+++ b/scenes/creep.tscn
@@ -4,3 +4,5 @@
 
 [node name="Creep" type="Node2D"]
 script = ExtResource(1)
+max_health = 10
+health = 10

--- a/scripts/creep.gd
+++ b/scripts/creep.gd
@@ -1,6 +1,7 @@
 extends Node2D
 
 @export var speed: float = 50.0
+@export var max_health: int = 10
 @export var health: int = 10
 var path: Path2D
 var distance: float = 0.0
@@ -19,9 +20,10 @@ func _ready() -> void:
 
 
 func take_damage(amount: int) -> void:
-	health -= amount
-	if health <= 0:
-		queue_free()
+        health -= amount
+        queue_redraw()
+        if health <= 0:
+                queue_free()
 
 
 func _process(delta: float) -> void:
@@ -36,4 +38,10 @@ func _process(delta: float) -> void:
 
 
 func _draw() -> void:
-	draw_circle(Vector2.ZERO, 8.0, Color.RED)
+        draw_circle(Vector2.ZERO, 8.0, Color.RED)
+        var bar_width := 16.0
+        var bar_height := 4.0
+        var bar_offset := Vector2(-bar_width / 2, -12.0)
+        var ratio := float(health) / float(max_health)
+        draw_rect(Rect2(bar_offset, Vector2(bar_width, bar_height)), Color.RED)
+        draw_rect(Rect2(bar_offset, Vector2(bar_width * ratio, bar_height)), Color.GREEN)


### PR DESCRIPTION
## Summary
- track creep durability with a new `max_health` export
- draw a green/red health bar based on current health ratio
- configure default health values in creep scene

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a1ec2a37988321ba1ee8b155353ef5