### PR TITLE
Implement wave-based creep spawner

### DIFF
--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -8,3 +8,8 @@ script = ExtResource("1")
 [node name="Path2D" type="Path2D" parent="."]
 
 [node name="SpawnTimer" type="Timer" parent="."]
+
+[node name="WaveLabel" type="Label" parent="."]
+offset_left = 10.0
+offset_top = 10.0
+text = "Wave 1"

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -4,22 +4,51 @@ extends Node2D
 @onready var spawn_timer: Timer = $SpawnTimer
 @onready var creep_scene: PackedScene = preload("res://scenes/creep.tscn")
 @onready var tower_scene: PackedScene = preload("res://scenes/tower.tscn")
+@onready var wave_label: Label = get_node_or_null("WaveLabel")
+
+var waves := [
+        { "count": 5, "health_multiplier": 1.0, "interval": 1.0 },
+        { "count": 8, "health_multiplier": 1.2, "interval": 0.8 }
+]
+
+var current_wave: int = 0
+var creeps_spawned: int = 0
 
 
 func _ready() -> void:
-	if path.curve == null:
-		path.curve = Curve2D.new()
-	path.curve.clear_points()
-	path.curve.add_point(Vector2(0, 300))
-	path.curve.add_point(Vector2(600, 300))
-	spawn_timer.timeout.connect(_on_spawn_timer_timeout)
-	spawn_timer.start()
+        if path.curve == null:
+                path.curve = Curve2D.new()
+        path.curve.clear_points()
+        path.curve.add_point(Vector2(0, 300))
+        path.curve.add_point(Vector2(600, 300))
+        spawn_timer.timeout.connect(_on_spawn_timer_timeout)
+        start_wave()
+
+
+func start_wave() -> void:
+        if current_wave >= waves.size():
+                return
+        creeps_spawned = 0
+        var wave = waves[current_wave]
+        spawn_timer.wait_time = wave.interval
+        if wave_label:
+                wave_label.text = "Wave %d" % (current_wave + 1)
+        spawn_timer.start()
 
 
 func _on_spawn_timer_timeout() -> void:
-	var creep := creep_scene.instantiate()
-	creep.path = path
-	add_child(creep)
+        var wave = waves[current_wave]
+        var creep := creep_scene.instantiate()
+        creep.path = path
+        creep.health = int(creep.health * wave.health_multiplier)
+        add_child(creep)
+        creeps_spawned += 1
+        if creeps_spawned >= wave.count:
+                spawn_timer.stop()
+                current_wave += 1
+                if current_wave < waves.size():
+                        await get_tree().create_timer(2.0).timeout
+                        start_wave()
 
 
 func _unhandled_input(event: InputEvent) -> void:


### PR DESCRIPTION
## Summary
- Replace fixed timer with wave-based creep manager
- Configure waves with creep counts, health multipliers, and spawn intervals
- Display current wave using an optional `WaveLabel`

## Testing
- `godot --headless --check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a1ec2851348321947e5bf552bbc0a9