### PR TITLE
Add projectile scene and tower firing logic

### DIFF
--- a/scenes/projectile.tscn
+++ b/scenes/projectile.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://scripts/projectile.gd" type="Script" id=1]
+
+[node name="Projectile" type="Node2D"]
+script = ExtResource(1)
+

--- a/scripts/projectile.gd
+++ b/scripts/projectile.gd
@@ -1,0 +1,26 @@
+extends Node2D
+
+@export var speed: float = 200.0
+var target: Node2D
+var damage: int = 0
+
+
+func _ready() -> void:
+	queue_redraw()
+
+
+func _process(delta: float) -> void:
+	if target == null or !is_instance_valid(target):
+		queue_free()
+		return
+	var to_target := target.global_position - global_position
+	var dist := to_target.length()
+	if dist <= speed * delta or dist == 0:
+		target.take_damage(damage)
+		queue_free()
+	else:
+		global_position += to_target.normalized() * speed * delta
+
+
+func _draw() -> void:
+	draw_circle(Vector2.ZERO, 4.0, Color.YELLOW)

--- a/scripts/projectile.gd.uid
+++ b/scripts/projectile.gd.uid
@@ -1,0 +1,1 @@
+uid://jebhvqaxif7qk

--- a/scripts/tower.gd
+++ b/scripts/tower.gd
@@ -4,6 +4,7 @@ extends Node2D
 @export var fire_rate: float = 1.0
 @export var damage: int = 5
 var cooldown: float = 0.0
+const PROJECTILE_SCENE := preload("res://scenes/projectile.tscn")
 
 
 func _ready() -> void:
@@ -15,13 +16,17 @@ func _process(delta: float) -> void:
 	if cooldown <= 0.0:
 		var target = _get_target()
 		if target:
-			target.take_damage(damage)
+			var projectile := PROJECTILE_SCENE.instantiate()
+			projectile.global_position = global_position
+			projectile.target = target
+			projectile.damage = damage
+			get_tree().current_scene.add_child(projectile)
 			cooldown = 1.0 / fire_rate
 
 func _get_target() -> Node2D:
 	var closest: Node2D = null
 	var closest_dist := attack_range
-	for creep in get_tree().get_nodes_in_group("creeps"):
+	for creep: Node2D in get_tree().get_nodes_in_group("creeps"):
 		var dist := global_position.distance_to(creep.global_position)
 		if dist < closest_dist:
 			closest = creep


### PR DESCRIPTION
## Summary
- add projectile scene and script with homing movement and damage
- spawn projectiles from towers instead of applying damage directly

## Testing
- `godot3-server --headless --check project.godot` *(fails: Can't open project; config_version 5 incompatible with engine)*

------
https://chatgpt.com/codex/tasks/task_b_68a1ec284abc8321b0041462612bd336