### PR TITLE
Fix overlapping wave and gold labels in HUD

### DIFF
--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -25,7 +25,7 @@ offset_left = 10.0
 offset_top = 10.0
 text = "Gold: 0"
 
-[node name="WaveLabel" type="Label" parent="."]
+[node name="WaveLabel" type="Label" parent="UI"]
 offset_left = 10.0
-offset_top = 10.0
+offset_top = 30.0
 text = "Wave 1"

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -5,7 +5,7 @@ extends Node2D
 @onready var creep_scene: PackedScene = preload("res://scenes/creep.tscn")
 @onready var tower_scene: PackedScene = preload("res://scenes/tower.tscn")
 @onready var gold_label: Label = $UI/GoldLabel
-@onready var wave_label: Label = get_node_or_null("WaveLabel")
+@onready var wave_label: Label = $UI/WaveLabel
 
 var player_gold: int = 100
 


### PR DESCRIPTION
## Summary
- Stop the wave and gold texts from overlapping by moving the WaveLabel into the UI canvas layer
- Adjust WaveLabel's offset to sit below the gold text
- Update script to reference the new WaveLabel path

## Testing
- `godot3-server --headless --path . --check-resources` *(fails: config version 5 is incompatible with Godot 3.5.2)*

------
https://chatgpt.com/codex/tasks/task_b_68a1f35397c48321b9e4ef1f54d046ed