### PR TITLE
Add pathfinding and wave spawner prototype

### DIFF
--- a/scripts/creep_pathfinder.gd
+++ b/scripts/creep_pathfinder.gd
@@ -1,0 +1,18 @@
+extends Node2D
+
+@export var speed: float = 80.0
+@export var waypoints: Array[Vector2] = []
+var _current_index: int = 0
+
+func _process(delta: float) -> void:
+	if _current_index >= waypoints.size():
+		queue_free()
+		return
+	var target: Vector2 = waypoints[_current_index]
+	var to_target := target - global_position
+	var step := speed * delta
+	if to_target.length() <= step:
+		global_position = target
+		_current_index += 1
+	else:
+		global_position += to_target.normalized() * step

--- a/scripts/creep_pathfinder.gd.uid
+++ b/scripts/creep_pathfinder.gd.uid
@@ -1,0 +1,1 @@
+uid://bko77r1yzuyft

--- a/scripts/wave_spawner.gd
+++ b/scripts/wave_spawner.gd
@@ -1,0 +1,29 @@
+extends Node2D
+
+@export var creep_scene: PackedScene
+@export var waves: Array[Dictionary] = [ { "count": 5, "interval": 1.0 } ]
+var _current_wave: int = 0
+var _spawned_in_wave: int = 0
+var _timer: float = 0.0
+
+func _process(delta: float) -> void:
+	if _current_wave >= waves.size():
+		return
+	_timer -= delta
+	if _timer <= 0.0:
+		_spawn_creep()
+		var wave = waves[_current_wave]
+		_spawned_in_wave += 1
+		if _spawned_in_wave >= wave.count:
+			_current_wave += 1
+			_spawned_in_wave = 0
+			_timer = 2.0
+		else:
+			_timer = wave.interval
+
+func _spawn_creep() -> void:
+	if creep_scene == null:
+		return
+	var creep = creep_scene.instantiate()
+	creep.global_position = global_position
+	get_parent().add_child(creep)

--- a/scripts/wave_spawner.gd.uid
+++ b/scripts/wave_spawner.gd.uid
@@ -1,0 +1,1 @@
+uid://513w4mz9swogr


### PR DESCRIPTION
## Summary
- add creep_pathfinder script to move along waypoints
- add wave_spawner script to spawn creeps based on wave definitions

## Testing
- `godot --version` *(fails: command not found)*
- `gdlint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a1fac9d41883219a0724f7bd31e275