### PR TITLE
Integrate pathfinding and wave spawner

### DIFF
--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://d24tpyn5rxbm2"]
+[gd_scene load_steps=6 format=3 uid="uid://d24tpyn5rxbm2"]
 
 [ext_resource type="Script" uid="uid://bs2aucesg5meu" path="res://scripts/main.gd" id="1"]
 [ext_resource type="TileSet" uid="uid://cg1tk0eio6kmw" path="res://art/ground_tileset.tres" id="2"]
+[ext_resource type="Script" path="res://scripts/wave_spawner.gd" id="3"]
+[ext_resource type="PackedScene" path="res://scenes/creep.tscn" id="4"]
 
 [sub_resource type="Curve2D" id="1"]
 
@@ -19,7 +21,10 @@ tile_set = ExtResource("2")
 [node name="Path2D" type="Path2D" parent="."]
 curve = SubResource("1")
 
-[node name="SpawnTimer" type="Timer" parent="."]
+
+[node name="WaveSpawner" type="Node2D" parent="."]
+script = ExtResource("3")
+creep_scene = ExtResource("4")
 
 [node name="UI" type="CanvasLayer" parent="."]
 

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -14,7 +14,7 @@ script = ExtResource("1")
 tile_set = ExtResource("2")
 format = 2
 
-[node name="Layer0" type="TileMapLayer" parent="TileMap"]
+[node name="Layer1" type="TileMapLayer" parent="TileMap"]
 use_parent_material = true
 tile_set = ExtResource("2")
 
@@ -41,5 +41,6 @@ text = "Wave 1"
 [node name="BuildButton" type="Button" parent="UI"]
 offset_left = 10.0
 offset_top = 60.0
-text = "Build Tower"
 toggle_mode = true
+text = "Build Tower"
+

--- a/scripts/creep.gd
+++ b/scripts/creep.gd
@@ -1,10 +1,8 @@
-extends Node2D
+extends CreepPathfinder
 
 @export var speed: float = 50.0
 @export var max_health: int = 10
 @export var health: int = 10
-var path: Path2D
-var distance: float = 0.0
 
 
 func _enter_tree() -> void:
@@ -27,15 +25,6 @@ func take_damage(amount: int) -> void:
 		queue_free()
 
 
-func _process(delta: float) -> void:
-	if path == null:
-		return
-	distance += speed * delta
-	var curve := path.curve
-	var length := curve.get_baked_length()
-	global_position = path.to_global(curve.sample_baked(distance))
-	if distance >= length:
-		queue_free()
 
 
 func _draw() -> void:

--- a/scripts/creep_pathfinder.gd
+++ b/scripts/creep_pathfinder.gd
@@ -1,18 +1,20 @@
 extends Node2D
 
+class_name CreepPathfinder
+
 @export var speed: float = 80.0
 @export var waypoints: Array[Vector2] = []
 var _current_index: int = 0
 
 func _process(delta: float) -> void:
 	if _current_index >= waypoints.size():
-		queue_free()
-		return
+	queue_free()
+	return
 	var target: Vector2 = waypoints[_current_index]
 	var to_target := target - global_position
 	var step := speed * delta
 	if to_target.length() <= step:
-		global_position = target
-		_current_index += 1
+	global_position = target
+	_current_index += 1
 	else:
-		global_position += to_target.normalized() * step
+	global_position += to_target.normalized() * step

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -15,89 +15,89 @@ var player_gold: int = 100
 var selected_tower_scene: PackedScene = null
 
 var waves := [
-	{ "count": 5, "health_multiplier": 1.0, "interval": 1.0 },
-	{ "count": 8, "health_multiplier": 1.2, "interval": 0.8 }
+    { "count": 5, "health_multiplier": 1.0, "interval": 1.0 },
+    { "count": 8, "health_multiplier": 1.2, "interval": 0.8 }
 ]
 
 func _ready() -> void:
-	if path.curve == null:
-		path.curve = Curve2D.new()
-	path.curve.clear_points()
-	path.curve.add_point(Vector2(0, 300))
-	path.curve.add_point(Vector2(600, 300))
-	for x in range(40):
-		for y in range(25):
-			tile_map.set_cell(0, Vector2i(x, y), 0, Vector2i.ZERO)
-	wave_spawner.creep_scene = creep_scene
-	wave_spawner.waves = waves
-	wave_spawner.waypoints = _get_waypoints()
-	wave_spawner.wave_started.connect(_on_wave_started)
-	_update_gold_label()
-	var temp_tower: Node = tower_scene.instantiate()
-	build_button.text = "Build Tower (%d)" % temp_tower.cost
-	build_button.toggled.connect(_on_build_button_toggled)
-	temp_tower.queue_free()
-	_on_wave_started(0)
+    if path.curve == null:
+        path.curve = Curve2D.new()
+    path.curve.clear_points()
+    path.curve.add_point(Vector2(0, 300))
+    path.curve.add_point(Vector2(600, 300))
+    for x in range(40):
+        for y in range(25):
+            tile_map.set_cell(0, Vector2i(x, y), 0, Vector2i.ZERO)
+    wave_spawner.creep_scene = creep_scene
+    wave_spawner.waves = waves
+    wave_spawner.waypoints = _get_waypoints()
+    wave_spawner.wave_started.connect(_on_wave_started)
+    _update_gold_label()
+    var temp_tower: Node = tower_scene.instantiate()
+    build_button.text = "Build Tower (%d)" % temp_tower.cost
+    build_button.toggled.connect(_on_build_button_toggled)
+    temp_tower.queue_free()
+    _on_wave_started(0)
 
 func _unhandled_input(event: InputEvent) -> void:
-	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-		if selected_tower_scene == null:
-			return
-		var cell := _world_to_cell(event.position)
-		if not _is_cell_free(cell):
-			return
-		if _is_on_path(event.position):
-			return
-		var tower := selected_tower_scene.instantiate()
-		if spend_gold(tower.cost):
-			tower.global_position = _cell_to_world(cell)
-			add_child(tower)
-			occupied_cells[cell] = true
-			build_button.button_pressed = false
-			selected_tower_scene = null
+    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+        if selected_tower_scene == null:
+            return
+        var cell := _world_to_cell(event.position)
+        if not _is_cell_free(cell):
+            return
+        if _is_on_path(event.position):
+            return
+        var tower := selected_tower_scene.instantiate()
+        if spend_gold(tower.cost):
+            tower.global_position = _cell_to_world(cell)
+            add_child(tower)
+            occupied_cells[cell] = true
+            build_button.button_pressed = false
+            selected_tower_scene = null
 
 func _world_to_cell(pos: Vector2) -> Vector2i:
-	return Vector2i(floor(pos.x / GRID_SIZE), floor(pos.y / GRID_SIZE))
+    return Vector2i(floor(pos.x / GRID_SIZE), floor(pos.y / GRID_SIZE))
 
 func _cell_to_world(cell: Vector2i) -> Vector2:
-	return Vector2(cell.x * GRID_SIZE + GRID_SIZE / 2, cell.y * GRID_SIZE + GRID_SIZE / 2)
+    return Vector2(cell.x * GRID_SIZE + GRID_SIZE / 2, cell.y * GRID_SIZE + GRID_SIZE / 2)
 
 func _is_cell_free(cell: Vector2i) -> bool:
-	return not occupied_cells.has(cell)
+    return not occupied_cells.has(cell)
 
 func _is_on_path(pos: Vector2) -> bool:
-	if path and path.curve:
-		var closest = path.curve.get_closest_point(pos)
-		return pos.distance_to(closest) < GRID_SIZE / 2
-	return false
+    if path and path.curve:
+        var closest = path.curve.get_closest_point(pos)
+        return pos.distance_to(closest) < GRID_SIZE / 2
+    return false
 
 func _get_waypoints() -> Array[Vector2]:
-	var pts: Array[Vector2] = []
-	var curve := path.curve
-	for i in range(curve.get_point_count()):
-		pts.append(path.to_global(curve.get_point_position(i)))
-	return pts
+    var pts: Array[Vector2] = []
+    var curve := path.curve
+    for i in range(curve.get_point_count()):
+        pts.append(path.to_global(curve.get_point_position(i)))
+    return pts
 
 func _on_wave_started(index: int) -> void:
-	if wave_label:
-		wave_label.text = "Wave %d" % (index + 1)
+    if wave_label:
+        wave_label.text = "Wave %d" % (index + 1)
 
 func _update_gold_label() -> void:
-	gold_label.text = "Gold: %d" % player_gold
+    gold_label.text = "Gold: %d" % player_gold
 
 func add_gold(amount: int) -> void:
-	player_gold += amount
-	_update_gold_label()
+    player_gold += amount
+    _update_gold_label()
 
 func spend_gold(amount: int) -> bool:
-	if player_gold >= amount:
-		player_gold -= amount
-		_update_gold_label()
-		return true
-	return false
+    if player_gold >= amount:
+        player_gold -= amount
+        _update_gold_label()
+        return true
+    return false
 
 func _on_build_button_toggled(pressed: bool) -> void:
-	if pressed:
-		selected_tower_scene = tower_scene
-	else:
-		selected_tower_scene = null
+    if pressed:
+        selected_tower_scene = tower_scene
+    else:
+        selected_tower_scene = null


### PR DESCRIPTION
## Summary
- Add `CreepPathfinder` base class to drive movement along waypoint arrays
- Update `Creep` to inherit pathfinding logic and remove hardcoded Path2D
- Introduce configurable `WaveSpawner` that emits wave start events and assigns waypoints
- Configure main scene to use wave spawner and provide path waypoints

## Testing
- ⚠️ `godot --headless --check-only project.godot` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a1fc2f8d548321a047a02886596eca